### PR TITLE
Add StructEval evaluation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,15 @@ Mike Conover, Matt Hayes, Ankit Mathur, et al. *2023*. [[Source](https://www.dat
 
 ### Data for LLM Evaluation
 
-1. **MMMU: A Massive Multi-discipline Multimodal Understanding and Reasoning Benchmark for Expert AGI**
+1. **StructEval: Benchmarking LLMs' Capabilities to Generate Structural Outputs**
+   Jialin Yang, Dongfu Jiang, Lipeng He, et al. *TMLR 2025*. [[Paper](https://openreview.net/forum?id=buDwV7LUA7)] [[Code](https://github.com/TIGER-AI-Lab/StructEval)] [[Dataset](https://huggingface.co/datasets/TIGER-Lab/StructEval)]
+2. **MMMU: A Massive Multi-discipline Multimodal Understanding and Reasoning Benchmark for Expert AGI**
    Xiang Yue, Yuansheng Ni, Kai Zhang, et al. *CVPR 2024*. [[Paper](https://openaccess.thecvf.com/content/CVPR2024/papers/Yue_MMMU_A_Massive_Multi-discipline_Multimodal_Understanding_and_Reasoning_Benchmark_for_CVPR_2024_paper.pdf)]
-2. **LexEval: A Comprehensive Chinese Legal Benchmark for Evaluating Large Language Models**
+3. **LexEval: A Comprehensive Chinese Legal Benchmark for Evaluating Large Language Models**
    Haitao Li, You Chen, Qingyao Ai, et al. *NeurIPS 2024*. [[Paper](https://arxiv.org/abs/2409.20288)]
-3. **What disease does this patient have? a large-scale open domain question answering dataset from medical exams**
+4. **What disease does this patient have? a large-scale open domain question answering dataset from medical exams**
    Di Jin, Eileen Pan, Nassim Oufattole, et al. *AAAI 2021*. [[Paper](https://arxiv.org/abs/2009.13081)]
-4. **Evaluating Large Language Models Trained on Code**
+5. **Evaluating Large Language Models Trained on Code**
    Mark Chen, Jerry Tworek, Heewoo Jun, et al. *arXiv 2021*. [[Paper](https://arxiv.org/abs/2107.03374)]
 
 ### Data for LLM Agents


### PR DESCRIPTION
## Summary

Add StructEval to the Data for LLM Evaluation section in reverse chronological order.

## Why it fits

StructEval is a TMLR benchmark and dataset for evaluating structured-output generation and conversion across 2,035 examples, 18 text and visual formats, and 44 task types. The entry follows the section's paper format and links the publication, code, and dataset.

## Validation

- checked the current tree, full Git history, and all prior pull requests, issues, and discussions for duplicates
- verified the primary publication, code, and dataset links
- preserved the repository's CRLF line-ending convention
- `git diff --check` with CRLF-aware whitespace handling

I maintain StructEval and am submitting this entry transparently for maintainer review.

This contribution was prepared with assistance from OpenAI Codex.
